### PR TITLE
Throw away the custom MarshalJSON function on OVTime

### DIFF
--- a/time.go
+++ b/time.go
@@ -8,10 +8,6 @@ import (
 
 type OVTime time.Time
 
-func (t OVTime) MarshalJSON() ([]byte, error) {
-	return []byte(string(time.Time(t).Unix() * 1000)), nil
-}
-
 func (t *OVTime) UnmarshalJSON(b []byte) error {
 	var millis int64
 	if err := json.Unmarshal(b, &millis); err != nil {


### PR DESCRIPTION
The output of this would pretty much always be invalid JSON, which would make encoding of the OVTime struct or any struct containing it fail.